### PR TITLE
update image.save to run callback only after image finishes saving

### DIFF
--- a/lib/image.js
+++ b/lib/image.js
@@ -94,8 +94,7 @@ image.save = function(ctx, save, cb) {
     stream.on('data', function(chunk) {
         out.write(chunk);
     }).on('end', function() {
-        out.end();
-        cb();
+        out.end(cb);
     });
 };
 


### PR DESCRIPTION
Fixes an issue in `image.save` where the callback is run before the file is completely written to disk. If the callback reads the file from disk, it sometimes gets a partial file. 

Before, the callback was run on the incoming data stream's end event. This could occur before the file was fully written. 

Now, the callback is passed to `out.end`, which fires it when it finishes writing the file (on it's finish event).

Fun project by the way! 
